### PR TITLE
Renaming file and deleting random files from original repo that alway…

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -1,0 +1,29 @@
+---
+  name: Push AlphaFold3 image to GitHub Registry
+  run-name: Pushing image after ${{ github.actor }}'s latest push
+
+  on:
+    push:
+      branches:
+        - main
+  
+  jobs:
+    build:
+      name: Build
+      runs-on: ubuntu-20.04
+      steps:
+        - name: Checkout Repo
+          uses: actions/checkout@v4
+        - name: Registry Login
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Build and push
+          uses: docker/build-push-action@v5
+          with:
+            push: true
+            file: Dockerfile
+            tags: | 
+              ghcr.io/washu-it-ris/alphafold3_wustl_fork_agora_implementation:latest


### PR DESCRIPTION
Most of the GH Actions files in the original repo (stuff like linting and unit tests) spawn jobs that fail because the needed framework isn't there.  Removing them to reduce noise in Github Actions.